### PR TITLE
Build a basic voting app!

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,19 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find(session[:user_id])
   end
 
+  def authenticate_user!
+    unless current_user
+      redirect_to :login, alert: 'You must be signed in to do that.'
+    end
+  end
+
+  def validate_session!
+    if session[:expires_at] && session[:expires_at] < Time.current
+      clear_session!
+      redirect_to :login, alert: 'Your session expired. Sign in again to resume voting.'
+    end
+  end
+
   def clear_session!
     session[:user_id] = nil
     session[:expires_at] = nil

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,14 @@
 class ApplicationController < ActionController::Base
+  private
+
+  def current_user
+    return unless session[:user_id]
+
+    @current_user ||= User.find(session[:user_id])
+  end
+
+  def clear_session!
+    session[:user_id] = nil
+    session[:expires_at] = nil
+  end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,0 +1,26 @@
+class UserSessionsController < ApplicationController
+  def new
+    if current_user
+      redirect_to :vote
+    end
+  end
+
+  def create
+    email = params.require(:email)
+    zip_code = params.require(:zip_code)
+
+    user = User.find_or_initialize_by(email: email)
+
+    user.update!(zip_code: zip_code) unless user.zip_code == zip_code
+    session[:user_id] = user.id
+    session[:expires_at] = 5.minutes.from_now
+
+    redirect_to :vote
+  end
+
+  def destroy
+    clear_session!
+
+    redirect_to :login, notice: 'You have successfully logged out.'
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -3,6 +3,8 @@ class UserSessionsController < ApplicationController
     if current_user
       redirect_to :vote
     end
+
+    @show_results_link = true
   end
 
   def create

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -13,16 +13,27 @@ class UserSessionsController < ApplicationController
 
     user = User.find_or_initialize_by(email: email)
 
-    user.update!(zip_code: zip_code) unless user.zip_code == zip_code
-    session[:user_id] = user.id
-    session[:expires_at] = 5.minutes.from_now
+    if Vote.exists?(user_id: user.id)
+      redirect_to :results, notice: 'Your vote has already been recorded.'
+    else
+      user.update!(zip_code: zip_code) unless user.zip_code == zip_code
+      session[:user_id] = user.id
+      session[:expires_at] = 5.minutes.from_now
 
-    redirect_to :vote
+      redirect_to :vote
+    end
   end
 
   def destroy
     clear_session!
 
-    redirect_to :login, notice: 'You have successfully logged out.'
+    flash_message =
+      if params[:expired]
+        { alert: 'Your session expired. Sign in again to resume voting.' }
+      else
+        { notice: 'You have successfully logged out.' }
+      end
+
+    redirect_to :login, flash_message
   end
 end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -1,0 +1,3 @@
+class VotesController < ApplicationController
+  def new;end
+end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -1,8 +1,38 @@
 class VotesController < ApplicationController
+  before_action :authenticate_user!, except: [:index]
+  before_action :validate_session!, except: [:index]
+  after_action :clear_session!, only: [:create]
+
   def index
     @vote_counts_per_candidate = Vote.read_cached_votes
     @votes_counted_at = Vote.cached_votes_updated_at
   end
 
-  def new;end
+  def new
+    if Vote.exists?(user: current_user)
+      redirect_to :results, notice: 'Your vote has already been recorded.'
+    end
+
+    @candidates = Candidate.order('LOWER(name)')
+    @can_write_in = @candidates.length < Candidate::MAX_CANDIDATES
+    @expires_at = session[:expires_at]
+  end
+
+  def create
+    candidate_id = params.require(:candidate_id)
+    candidate =
+      if candidate_id == 'other' && params.permit(:write_in)
+        Candidate.create(name: params[:write_in])
+      else
+        Candidate.find(candidate_id)
+      end
+
+    Vote.create!(user: current_user, candidate: candidate)
+
+    if Vote.count % Vote::CACHE_INCREMENT == 0
+      Vote.write_cached_votes
+    end
+
+    redirect_to :results, notice: 'Your vote has been recorded.'
+  end
 end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -1,3 +1,8 @@
 class VotesController < ApplicationController
+  def index
+    @vote_counts_per_candidate = Vote.read_cached_votes
+    @votes_counted_at = Vote.cached_votes_updated_at
+  end
+
   def new;end
 end

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,5 @@
 
 import { application } from "./application"
 
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
+import VoteController from "./vote_controller"
+application.register("vote", VoteController)

--- a/app/javascript/controllers/vote_controller.js
+++ b/app/javascript/controllers/vote_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="vote"
+export default class extends Controller {
+  static targets = ["countdown", "form", "other", "writeIn"];
+
+  connect() {
+    this.sessionExpiresAt = this.countdownTarget.dataset.sessionExpiresAt;
+    this.endTime = new Date(this.sessionExpiresAt);
+    this.countdown = setInterval(this.countdown.bind(this), 1000);
+    this.canWriteIn = this.formTarget.dataset.canWriteIn === "true";
+    this.formTarget.querySelector("input").focus();
+  }
+
+  countdown() {
+    const now = new Date();
+    const secondsRemaining = (this.endTime - now) / 1000;
+
+    if (secondsRemaining <= 0) {
+      clearInterval(this.countdown);
+      this.countdownTarget.innerHTML = "Signing out...";
+      setTimeout(this.endSession, 1000);
+      return;
+    }
+
+    const secondsPerHour = 3600;
+    const secondsPerMinute = 60;
+    const minutes = Math.floor(
+      (secondsRemaining % secondsPerHour) / secondsPerMinute
+    );
+    const seconds = Math.floor(secondsRemaining % secondsPerMinute);
+
+    this.countdownTarget.innerHTML = `${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
+  }
+
+  endSession() {
+    window.location.replace("/logout?expired=true");
+  }
+
+  selectOther() {
+    this.otherTarget.checked = true;
+  }
+
+  focusWriteIn() {
+    this.writeInTarget.focus()
+  }
+
+  clearWriteIn() {
+    if (this.canWriteIn) {
+      this.writeInTarget.value = "";
+    }
+  }
+
+  disconnect() {
+    clearInterval(this.countdown);
+  }
+}

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -1,0 +1,26 @@
+<ul class="flex justify-between mb-12 bg-gray-100 p-10 border-blue-500 align-center">
+  <li class="mr-3">
+    <form action="/" method="get" accept-charset="UTF-8">
+      <button class="bg-transparent text-blue-700 hover:border-blue-500 focus:border-blue-500 rounded text-2xl">
+        vote.app
+      </button>
+    </form>
+  </li>
+  <% if @current_user %>
+    <div class="flex flex-row align-center">
+      <li class="mr-3">
+        <p class="text-md">signed in as: <%= @current_user.email %></p>
+      </li>
+      <li class="mr-3">
+        |
+      </li>
+      <li>
+        <form action="/logout" method="get" accept-charset="UTF-8">
+          <button class="bg-transparent hover:bg-blue-500 focus:bg-blue-500 text-blue-700 hover:text-white focus:text-white px-4 border border-blue-500 hover:border-transparent focus:border-transparent rounded">
+            Logout
+          </button>
+        </form>
+      </li>
+    </div>
+  <% end %>
+</ul>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -22,5 +22,13 @@
         </form>
       </li>
     </div>
+  <% elsif @show_results_link %>
+    <li class="mr-3">
+    <form action="/results" method="get" accept-charset="UTF-8">
+      <button class="bg-transparent hover:bg-blue-500 focus:bg-blue-500 text-blue-700 hover:text-white focus:text-white px-4 border border-blue-500 hover:border-transparent focus:border-transparent rounded">
+        View results
+      </button>
+    </form>
+  </li>
   <% end %>
 </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>AbVotingApp</title>
+    <title>VOTE.APP</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -12,7 +12,20 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-28 px-5 flex">
+    <% flash.each do |type, msg| %>
+        <% if type == "notice" %>
+          <div class="p-4 mb-2 text-xl text-blue-800 rounded-lg bg-blue-50 flex justify-center" role="alert">
+            <span class="font-medium mr-1"><%= msg %></span>
+        <% elsif type == "alert" %>
+          <div class="p-4 mb-2 text-xl text-red-800 rounded-lg bg-red-50 flex justify-center" role="alert">
+            <span class="font-medium mr-1"><%= msg %></span>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%= render "layouts/nav" %>
+
+    <main class="container px-10 flex-auto flex-col">
       <%= yield %>
     </main>
   </body>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,0 +1,21 @@
+<h1 class="mb-4 text-4xl">Sign in to vote</h1>
+
+<div class="relative overflow-x-auto max-w-md">
+  <form action="/login" method="post" accept-charset="UTF-8" class="flex flex-col">
+    <div class="flex flex-row items-center mb-2 justify-between">
+      <label for="email" class="text-xl">Email address:</label>
+      <input id="email" name="email" type="email" class="ml-2" required aria-required="true"/>
+    </div>
+
+    <div class="flex flex-row items-center mb-2 justify-between">
+      <label for="zip_code" class="text-xl">Zip code (5 digits):</label>
+      <input id="zip_code" name="zip_code" type="text" class="ml-2" required aria-required="true" pattern="[0-9]{5}" />
+    </div>
+
+    <div class="flex flex-row justify-center pt-4 mb-2">
+      <button class="bg-transparent hover:bg-blue-500 focus:bg-blue-500 text-blue-700 font-semibold hover:text-white focus:text-white py-2 px-12 border border-blue-500 hover:border-transparent focus:border-transparent rounded">
+        Sign in
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <div class="flex flex-row justify-center pt-4 mb-2">
-      <button class="bg-transparent hover:bg-blue-500 focus:bg-blue-500 text-blue-700 font-semibold hover:text-white focus:text-white py-2 px-12 border border-blue-500 hover:border-transparent focus:border-transparent rounded">
+      <button class="bg-blue-500 hover:bg-blue-700 focus:bg-blue-700 text-white font-bold py-2 px-12 rounded">
         Sign in
       </button>
     </div>

--- a/app/views/votes/index.html.erb
+++ b/app/views/votes/index.html.erb
@@ -1,0 +1,23 @@
+<h1 class="mb-4 text-4xl">Election Results</h1>
+
+<div class="relative overflow-x-auto max-w-md">
+  <% if @vote_counts_per_candidate %>
+    <p class="mb-4 text-md">Results last updated: <%= time_ago_in_words(@votes_counted_at) %> ago</p>
+    <table class="w-full text-sm text-left rtl:text-right text-gray-500">
+      <tbody>
+        <% @vote_counts_per_candidate.each do |name, count| %>
+          <tr class="bg-white border-y">
+            <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap">
+              <%= name %>
+            </th>
+            <td class="px-6 py-4">
+              <%= count %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p class="text-lg">Results coming soon!</p>
+  <% end %>
+</div>

--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -1,0 +1,44 @@
+<div data-controller="vote">
+  <ul class="flex flex-row justify-between">
+    <li>
+      <h1 class="mb-4 text-4xl">Cast your vote!</h1>
+    </li>
+    <li>
+      <h4 class="mb-4 text-xl">Session time remaining:
+        <span data-vote-target="countdown" data-session-expires-at="<%= @expires_at %>">(calculating...)</span>
+      </h4>
+    </li>
+  </ul>
+
+  <div class="relative overflow-x-auto max-w-md">
+    <form action="/vote" method="post" accept-charset="UTF-8" class="flex flex-col" data-vote-target="form" data-can-write-in="<%= @can_write_in %>">
+      <% if @candidates.length > 0 %>
+        <% @candidates.each do |c| %>
+          <div class="flex flex-row items-center mb-2 ml-1">
+            <input type="radio" name="candidate_id" value="<%= c.id %>" id="<%= c.id %>" data-action="click->vote#clearWriteIn" />
+            <label for="<%= c.id %>" class="ml-2"><%= c.name %></label>
+          </div>
+        <% end %>
+      <% end %>
+      <% if @can_write_in %>
+        <div class="flex flex-row items-center ml-1">
+          <input type="radio" name="candidate_id" value="other" id="other" data-vote-target="other" data-action="click->vote#focusWriteIn">
+          <label for="other" class="ml-2">Other (write in below)</label>
+        </div>
+
+        <hr class="my-4" />
+
+        <div class="flex flex-row items-center">
+          <label for="write_in">Add a new candidate:</label>
+          <input id="write_in" name="write_in" type="text" class="ml-2" data-vote-target="writeIn" data-action="focus->vote#selectOther" />
+        </div>
+      <% end %>
+
+      <div class="flex flex-row justify-center pt-4 mb-2">
+        <button class="bg-blue-500 hover:bg-blue-700 focus:bg-blue-700 text-white font-bold py-2 px-12 rounded">
+          Vote!
+        </button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,19 +19,19 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp/caching-dev.txt").exist?
+  # if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :redis_cache_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
-  else
-    config.action_controller.perform_caching = false
+  # else
+  #   config.action_controller.perform_caching = false
 
-    config.cache_store = :null_store
-  end
+  #   config.cache_store = :null_store
+  # end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get '/logout', to: 'user_sessions#destroy'
 
   get '/vote', to: 'votes#new', as: :vote
+  post '/vote', to: 'votes#create'
 
   get '/results', to: 'votes#index', as: :results
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,11 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "user_sessions#new"
+
+  get '/login', to: 'user_sessions#new', as: :login
+  post '/login', to: 'user_sessions#create'
+  get '/logout', to: 'user_sessions#destroy'
+
+  get '/vote', to: 'votes#new', as: :vote
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,6 @@ Rails.application.routes.draw do
   get '/logout', to: 'user_sessions#destroy'
 
   get '/vote', to: 'votes#new', as: :vote
+
+  get '/results', to: 'votes#index', as: :results
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  describe 'clear_session!' do
+    subject { controller.send(:clear_session!) }
+
+    before do
+      session[:user_id] = SecureRandom.uuid
+      session[:expires_at] = Time.current
+    end
+
+    it 'clears the session user_id' do
+      subject
+      expect(session[:user_id]).to be_nil
+    end
+
+    it 'clears the session expires_at' do
+      subject
+      expect(session[:expires_at]).to be_nil
+    end
+  end
+end

--- a/spec/controllers/user_sessions_controller_spec.rb
+++ b/spec/controllers/user_sessions_controller_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe UserSessionsController, type: :controller do
+  describe 'GET #new' do
+    subject { get :new }
+
+    it { should have_http_status(:success) }
+
+    context 'when already signed in' do
+      let(:user) { create(:user) }
+      before { session[:user_id] = user.id }
+
+      it { should redirect_to(:vote) }
+    end
+  end
+
+  describe 'POST #create' do
+    let(:params) do
+      { email: "a@b.com", zip_code: "12345" }
+    end
+    subject { post :create, params: params }
+
+    context 'when the user email is not in the database' do
+      it 'creates a new user record' do
+        expect { subject }.to change { User.count }.by(1)
+        user = User.last
+        expect(user.email).to eq(params[:email])
+      end
+    end
+
+    context 'when the user email exists in the database' do
+      let!(:user) { create(:user, params) }
+      it 'does not create a new record' do
+        expect { subject }.to_not change { User.count }
+      end
+
+      it 'updates the record if the zip code has changed' do
+        new_zip = "54321"
+        params[:zip_code] = new_zip
+        expect_any_instance_of(User).to receive(:update!).and_call_original
+        subject
+        expect(user.reload.zip_code).to eq(new_zip)
+      end
+
+      it 'does not update the record if the zip code is the same' do
+        expect_any_instance_of(User).to_not receive(:update!)
+        subject
+      end
+    end
+
+    it 'sets the session with the user id' do
+      user = create(:user, params)
+      subject
+      expect(session[:user_id]).to eq(user.id)
+    end
+  end
+
+  describe 'GET #destroy' do
+    subject { get :destroy }
+
+    it 'calls clear_session!' do
+      expect(controller).to receive(:clear_session!)
+      subject
+    end
+
+    it { should redirect_to(:login) }
+
+    it 'sets a flash notice' do
+      subject
+      expect(flash[:notice]).to eq('You have successfully logged out.')
+    end
+  end
+end

--- a/spec/controllers/user_sessions_controller_spec.rb
+++ b/spec/controllers/user_sessions_controller_spec.rb
@@ -20,38 +20,54 @@ RSpec.describe UserSessionsController, type: :controller do
     end
     subject { post :create, params: params }
 
-    context 'when the user email is not in the database' do
-      it 'creates a new user record' do
-        expect { subject }.to change { User.count }.by(1)
-        user = User.last
-        expect(user.email).to eq(params[:email])
+    context 'when the user has already voted' do
+      let(:user) { create(:user, params) }
+      before do
+        session[:user_id] = user.id
+        create(:vote, user: user)
+      end
+
+      it { should redirect_to(:results) }
+      it 'sets a flash notice' do
+        subject
+        expect(flash[:notice]).to eq('Your vote has already been recorded.')
       end
     end
 
-    context 'when the user email exists in the database' do
-      let!(:user) { create(:user, params) }
-      it 'does not create a new record' do
-        expect { subject }.to_not change { User.count }
+    context 'when the user has not yet voted' do
+      context 'when the user email is not in the database' do
+        it 'creates a new user record' do
+          expect { subject }.to change { User.count }.by(1)
+          user = User.last
+          expect(user.email).to eq(params[:email])
+        end
       end
 
-      it 'updates the record if the zip code has changed' do
-        new_zip = "54321"
-        params[:zip_code] = new_zip
-        expect_any_instance_of(User).to receive(:update!).and_call_original
+      context 'when the user email exists in the database' do
+        let!(:user) { create(:user, params) }
+        it 'does not create a new record' do
+          expect { subject }.to_not change { User.count }
+        end
+
+        it 'updates the record if the zip code has changed' do
+          new_zip = "54321"
+          params[:zip_code] = new_zip
+          expect_any_instance_of(User).to receive(:update!).and_call_original
+          subject
+          expect(user.reload.zip_code).to eq(new_zip)
+        end
+
+        it 'does not update the record if the zip code is the same' do
+          expect_any_instance_of(User).to_not receive(:update!)
+          subject
+        end
+      end
+
+      it 'sets the session with the user id' do
+        user = create(:user, params)
         subject
-        expect(user.reload.zip_code).to eq(new_zip)
+        expect(session[:user_id]).to eq(user.id)
       end
-
-      it 'does not update the record if the zip code is the same' do
-        expect_any_instance_of(User).to_not receive(:update!)
-        subject
-      end
-    end
-
-    it 'sets the session with the user id' do
-      user = create(:user, params)
-      subject
-      expect(session[:user_id]).to eq(user.id)
     end
   end
 
@@ -68,6 +84,15 @@ RSpec.describe UserSessionsController, type: :controller do
     it 'sets a flash notice' do
       subject
       expect(flash[:notice]).to eq('You have successfully logged out.')
+    end
+
+    context 'when called with expired param' do
+      subject { get :destroy, params: { expired: true } }
+
+      it 'sets a flash alert' do
+        subject
+        expect(flash[:alert]).to eq('Your session expired. Sign in again to resume voting.')
+      end
     end
   end
 end

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe VotesController, type: :controller do
+  describe 'GET #index' do
+    subject { get :index }
+    context 'when not signed in' do
+      it { should have_http_status(:success) }
+    end
+
+    context 'when signed in' do
+      let(:user) { create(:user) }
+      before { session[:user_id] = user.id }
+
+      it { should have_http_status(:success) }
+    end
+
+    it 'loads cached voting results' do
+      expect(Vote).to receive(:read_cached_votes)
+      subject
+    end
+
+    it 'loads the cached timestamp for when voting results were updated' do
+      expect(Vote).to receive(:cached_votes_updated_at)
+      subject
+    end
+  end
+end

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -24,4 +24,120 @@ RSpec.describe VotesController, type: :controller do
       subject
     end
   end
+
+  describe 'GET #new' do
+    subject { get :new }
+
+    context 'when not signed in' do
+      it {
+        should redirect_to(:login)
+        expect(flash[:alert]).to eq('You must be signed in to do that.')
+      }
+    end
+
+    context 'when signed in' do
+      let(:user) { create(:user) }
+      before { session[:user_id] = user.id }
+
+      context 'and the user has already voted' do
+        before { create(:vote, user: user) }
+
+        it { should redirect_to(:results) }
+        it 'sets a flash notice' do
+          subject
+          expect(flash[:notice]).to eq('Your vote has already been recorded.')
+        end
+      end
+
+      context 'and the user has not yet voted' do
+        context 'and the user session has expired' do
+          before { session[:expires_at] = 1.minute.ago }
+          it {
+            should redirect_to(:login)
+            expect(flash[:alert]).to eq('Your session expired. Sign in again to resume voting.')
+          }
+        end
+
+        context 'and the user session has not expired' do
+          before { session[:expires_at] = 1.minute.from_now }
+          it { should have_http_status(:success) }
+        end
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    let(:params) { {} }
+    subject { post :create, params: params }
+
+    context 'when not signed in' do
+      it {
+        should redirect_to(:login)
+        expect(flash[:alert]).to eq('You must be signed in to do that.')
+      }
+    end
+
+    context 'when signed in' do
+      let(:user) { create(:user) }
+      let(:candidate) { create :candidate }
+      before { session[:user_id] = user.id }
+
+      context 'when voting for an existing candidate' do
+        let(:params) do
+          { candidate_id: candidate.id }
+        end
+
+        it 'creates a vote for that candidate and the current user' do
+          expect { subject }.to change { Vote.count }.by(1)
+          vote = Vote.last
+          expect(vote.user).to eq(user)
+          expect(vote.candidate).to eq(candidate)
+        end
+
+        it { should redirect_to(:results) }
+        it 'clears the session and sets a flash notice' do
+          expect(controller).to receive(:clear_session!)
+          subject
+          expect(flash[:notice]).to eq('Your vote has been recorded.')
+        end
+      end
+
+      context 'when voting for a write-in candidate' do
+        let(:candidate_name) { SecureRandom.hex }
+        let(:params) do
+          { candidate_id: 'other', write_in: candidate_name }
+        end
+
+        it 'creates a new candidate' do
+          expect { subject }.to change { Candidate.count }.by(1)
+        end
+
+        it 'creates a vote for that candidate and the current user' do
+          expect { subject }.to change { Vote.count }.by(1)
+          vote = Vote.last
+          expect(vote.user).to eq(user)
+          expect(vote.candidate).to eq(Candidate.last)
+        end
+
+        it { should redirect_to(:results) }
+        it 'clears the session and sets a flash notice' do
+          expect(controller).to receive(:clear_session!)
+          subject
+          expect(flash[:notice]).to eq('Your vote has been recorded.')
+        end
+      end
+
+      context 'when the new vote makes the total a factor of Vote::CACHE_INCREMENT' do
+        let(:params) do
+          { candidate_id: candidate.id }
+        end
+        before { expect(Vote).to receive(:count).and_return(Vote::CACHE_INCREMENT) }
+
+        it 'updates the votes cache' do
+          expect(Vote).to receive(:write_cached_votes).and_call_original
+          subject
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Requirements

This PR implements features that meet the following requirements:
* The app
  - is accessible to screen readers and keyboard navigation
  - accepts an email address and zip code on a sign-in form
  - presents the current list of candidates and the ability to add a candidate
  - shows the current results tabulated per candidate on a separate, unauthenticated dashboard that updates once every 10 votes
* A given email address can vote 1 time
* There are no predetermined candidates, all candidates will come in the form of write-ins
* A write-in vote creates a new candidate on the form for the following voters to choose
* Adding a candidate will automatically cast a vote for that candidate
* There is a maximum of 10 unique candidates
* Everyone gets exactly 5 minutes to vote after signing in before they need to sign in again

*****

### Overview

This voting app has three pages:

#### 🔐 Sign in

* If the user is already signed in, accessing this page will redirect them to the voting page
* Signing in
  - creates a session that expires in five minutes
  -  redirects to the voting page
* If the user has already voted, signing in results in an immediate sign-out and redirects to the results page

<img width="742" alt="Screenshot 2023-12-18 at 6 55 23 PM" src="https://github.com/labe/ab_voting_app/assets/322660/8189b0ab-0681-4d61-b093-6220edefac1e">

#### 🗳️ Vote

* If the user is not signed in, they will be redirected to the sign-in page
* If the user has not submitted their vote by the time their five-minute session ends (indicated by a countdown timer on the page), they will be automatically signed out and redirected to the sign-in page

When the maximum number of candidates (see `Candidate::MAX_THRESHOLD`) has not been reached, a write-in option is shown:
<img width="889" alt="Screenshot 2023-12-18 at 5 34 52 PM" src="https://github.com/labe/ab_voting_app/assets/322660/efcd3e0e-31ed-47df-bd74-521fab7e5c47">

Once the maximum has been met, only the existing candidate names are shown:
<img width="888" alt="Screenshot 2023-12-18 at 5 32 42 PM" src="https://github.com/labe/ab_voting_app/assets/322660/bc9f7234-2a47-402f-9e14-44a53edb27e3">

#### 📊 Results

* Users do not need to be signed in to access the results page

For enhanced performance, voting results are cached, and only tabulated every 10 votes (see `Vote::CACHE_INCREMENT`). For the first nine votes, users will see an empty results page:
<img width="763" alt="Screenshot 2023-12-18 at 6 58 36 PM" src="https://github.com/labe/ab_voting_app/assets/322660/b5bd8182-f235-490e-9d5f-8bdb8ff766db">

Once votes have been cached, users will see the results as well as an indicator of how long ago the results were tabulated:
<img width="476" alt="Screenshot 2023-12-18 at 5 31 32 PM" src="https://github.com/labe/ab_voting_app/assets/322660/394260b3-cc4a-4a17-8167-46e8cfadaf33">

*****

### Notes

#### 🤝 Assumptions

* Users live in the USA and, as such, understand what their five-digit zip code is
* Users already know what they're voting for (i.e. random (but non-malicious) people aren't unexpectedly stumbling across the app)
* Due to PR scope, there is no authentication system; assume the sign-in information the user submits is intentional and in good faith
* Users are also acting in good faith when voting (i.e. submitted candidate names are in earnest, duplicates are not a concern, no one is submitting an empty voting form)
* The app is only asked to manage one active session at any given time

#### 📓 Design considerations

* In the interest of time / scope, a standard Rails app FE/BE was selected over a Rails API + React FE
* Controller callbacks are in place to ensure
  - a user has to be signed in to vote
  -  the only thing a user can do while signed in, is vote
* Storing the session expiration timestamp allows the user to close the page and reopen it to resume their session (an argument could be made that ending the session on page close is more secure; given the session duration is already fairly short, choosing to persist the session feels like an acceptable trade-off for user convenience)
* On the voting page, candidates are listed alphabetically
* On the results page, candidates are listed in descending order of total votes, with a secondary ascending order of name
* Candidate names are saved as a single string value, to avoid inherent assumptions about "first" and "last" names / name structure
* Candidate names are not sanitized or normalized (except for sorting); see above assumptions about good faith and intentional submissions
* The signed-in user's email is shown on the voting page to help identify their session is active
* A "last updated" time interval is shown on the results page to help avoid confusion as to why a user may not see their vote on the page (e.g. after voting for a new/write-in candidate)
* Flash banners are implemented to explain redirect behavior to the user

#### 🛠️ Future improvements?
* Add a modal confirmation on vote submission to give the user a chance to review their selection / write-in
* Implement ActionCable / Websockets to allow an open results page to automatically be updated by the server when new results have been tabulated
* Schedule a Sidekiq job to automatically destroy the user session after five minutes, in case the browser window redirect fails to happen
* Implement `counter_cache` to add a `votes_count` column on `Candidate` ?